### PR TITLE
Add rollup job to CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,3 +67,16 @@ jobs:
           using T4ARegistrator
           DocMeta.setdocmeta!(T4ARegistrator, :DocTestSetup, :(using T4ARegistrator); recursive=true)
           doctest(T4ARegistrator)
+  rollup:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - docs
+    if: always()
+    steps:
+      - name: All tests passed
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: exit 0
+      - name: Some tests failed or cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
This PR adds a rollup job to CI.yml, following the guidelines in AGENTS.md.

Changes:
- Add rollup job with `needs: [test, docs]`
- Use `if: always()` to run regardless of previous job results
- Check for both `failure` and `cancelled` statuses

Auto merge is already enabled for this repository.